### PR TITLE
fix: #83 Ensure that logs are correctly parsed when the user Left

### DIFF
--- a/VRCToolBox/VRCLog/Analyse/Model/VRCLogParser.cs
+++ b/VRCToolBox/VRCLog/Analyse/Model/VRCLogParser.cs
@@ -10,12 +10,12 @@ namespace VRCToolBox.VRCLog.Analyse.Model
     /// <summary>VRChatのログを解析するクラス</summary>
     internal class VRCLogParser : ILogParser
     {
-        private static readonly Regex _regex  = new Regex(@"(\d{4}\.\d{2}\.\d{2} \d{2}:\d{2}:\d{2}) Log\s+-\s+\[Behaviour\] (Initialized PlayerAPI|OnPlayerLeft|Entering Room:)\s+(.*)", RegexOptions.Compiled);
+        private static readonly Regex _regex = new Regex(@"(\d{4}\.\d{2}\.\d{2} \d{2}:\d{2}:\d{2}) Log\s+-\s+\[Behaviour\] (Initialized PlayerAPI|Unregistering|Entering Room:)\s+(.*)", RegexOptions.Compiled);
         private static readonly Regex _regex2 = new Regex(@"""([^""]+)""\s+(?:is (local|remote))", RegexOptions.Compiled);
         private static readonly List<string> _logEntries = new List<string>()
         {
             "Initialized PlayerAPI",
-            "OnPlayerLeft",
+            "Unregistering",
             "Entering Room:"
         };
 
@@ -25,16 +25,17 @@ namespace VRCToolBox.VRCLog.Analyse.Model
         internal static IParseLogResult? ParseLogLine(string? logLine)
         {
             if (string.IsNullOrWhiteSpace(logLine)) return null;
-            if(_logEntries.TrueForAll(x => !logLine.Contains(x))) return null;
+            if (_logEntries.TrueForAll(x => !logLine.Contains(x))) return null;
             //var regex  = new Regex(@"(\d{4}\.\d{2}\.\d{2} \d{2}:\d{2}:\d{2}) Log\s+-\s+\[Behaviour\] (Initialized PlayerAPI|OnPlayerLeft|Entering Room:)\s+(.*)", RegexOptions.Compiled);
             //var regex2 = new Regex(@"""([^""]+)""\s+(?:is (local|remote))", RegexOptions.Compiled);
-            var match  = _regex.Match(logLine);
+            var match = _regex.Match(logLine);
 
             // 一致しなければ null
             if (!match.Success || match.Groups.Count < 4) return null;
 
             // 戻り値の用意
-            var result = new ParseVRCLogResult {
+            var result = new ParseVRCLogResult
+            {
                 Timestamp = DateTime.Parse(match.Groups[1].Value)
             };
 
@@ -45,7 +46,7 @@ namespace VRCToolBox.VRCLog.Analyse.Model
             switch (action)
             {
                 // Left
-                case "OnPlayerLeft":
+                case "Unregistering":
                     result.PlayerName = details;
                     result.Action     = E_ActivityType.Left;
                     return result;


### PR DESCRIPTION
#83 
# 概要
ユーザーのLeft時のログを取得できない場合が散見される問題の解消のためのPRです。
前のPRのベースブランチを間違えていたので再作成しました。

# 修正の理由
VRChatのログの書き出し方の仕様が変わったのか、ユーザーのLeft時にOnPlayerLeftが必ずしもログとして出ないため、現状必ず出ていそうなUnregisteringに解析対象の文字列を変更しました。