### PR TITLE
fix #88 only settings can be copied

### DIFF
--- a/VRCToolBox/Pictures/Interface/IImageConvertTarget.cs
+++ b/VRCToolBox/Pictures/Interface/IImageConvertTarget.cs
@@ -49,6 +49,12 @@ namespace VRCToolBox.Pictures.Interface
         /// <param name="original">読み込む値を保持しているモデル</param>
         internal Task SetPropertiesAsync(IImageConvertTarget original, bool loadOptions);
 
+        /// <summary>
+        /// 引数のモデルから変換の設定を読み込みます
+        /// </summary>
+        /// <param name="original">読み込む値を保持しているモデル</param>
+        internal Task CopyConvertSettingsAsync(IImageConvertTarget original);
+
         internal Task SaveConvertedImageAsync(string directoryPath, System.Threading.CancellationToken token);
     }
 

--- a/VRCToolBox/Pictures/Model/ImageConverterModel.cs
+++ b/VRCToolBox/Pictures/Model/ImageConverterModel.cs
@@ -86,7 +86,7 @@ namespace VRCToolBox.Pictures.Model
                 // すべて同じ設定で変換する場合
                 foreach (var target in ConvertTargets)
                 {
-                    await target.SetPropertiesAsync(_selectTarget, true).ConfigureAwait(false);
+                    await target.CopyConvertSettingsAsync(_selectTarget).ConfigureAwait(false);
                 }
             }
             else

--- a/VRCToolBox/Pictures/Model/ImageConverterSubModel.cs
+++ b/VRCToolBox/Pictures/Model/ImageConverterSubModel.cs
@@ -153,6 +153,34 @@ namespace VRCToolBox.Pictures.Model
             }
         }
 
+        private async Task CopyConvertSettings(IImageConvertTarget original)
+        {
+            try
+            {
+                // 変更中にプレビューを何度も生成しないようにフラグを立てる
+                _nowLoadOption = true;
+
+                RawData.Value = ImageFileOperator.GetSKData(ImageFullName.Value);
+
+                ConvertFormat.Value = original.ConvertFormat.Value;
+                await LoadOptionsAsync(original).ConfigureAwait(false);
+
+                // フラグを解除、プレビューを生成
+                _nowLoadOption = false;
+                await RecieveOptionValueChangedAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                throw;
+            }
+            finally
+            {
+                // 念のためにフラグを解除
+                _nowLoadOption = false;
+            }
+        }
+
+
         private async Task LoadOptionsAsync(IImageConvertTarget original)
         {
             await ResizeOptions.SetOptionsAsync(original.ResizeOptions).ConfigureAwait(false);
@@ -176,6 +204,8 @@ namespace VRCToolBox.Pictures.Model
         }
 
         Task IImageConvertTarget.SetPropertiesAsync(IImageConvertTarget original, bool loadOptions) => SetPropertiesAsync(original, loadOptions);
+
+        Task IImageConvertTarget.CopyConvertSettingsAsync(IImageConvertTarget original) => CopyConvertSettings(original);
 
         Task IImageConvertTargetWithReactiveImage.RecieveOptionValueChangedAsync() => RecieveOptionValueChangedAsync();
 

--- a/VRCToolBox/Pictures/Model/ImageConverterTargetModel.cs
+++ b/VRCToolBox/Pictures/Model/ImageConverterTargetModel.cs
@@ -89,6 +89,12 @@ namespace VRCToolBox.Pictures.Model
             if (loadOptions) await LoadOptionsAsync(original).ConfigureAwait(false);
         }
 
+        private async Task CopyConvertSettings(IImageConvertTarget original)
+        {
+            ConvertFormat.Value = original.ConvertFormat.Value;
+            await LoadOptionsAsync(original).ConfigureAwait(false);
+        }
+
         private async Task LoadOptionsAsync(IImageConvertTarget original)
         {
             await ResizeOptions.SetOptionsAsync(original.ResizeOptions).ConfigureAwait(false);
@@ -148,6 +154,8 @@ namespace VRCToolBox.Pictures.Model
         }
 
         Task IImageConvertTarget.SetPropertiesAsync(IImageConvertTarget original, bool loadOptions) => SetPropertiesAsync(original, loadOptions);
+
+        Task IImageConvertTarget.CopyConvertSettingsAsync(IImageConvertTarget original) => CopyConvertSettings(original);
 
         Task IImageConvertTarget.SaveConvertedImageAsync(string directoryPath, System.Threading.CancellationToken token) => SaveConvertedImageAsync(directoryPath, token);
     }


### PR DESCRIPTION
#88 

# 概要
「同じ設定で変換する」にチェックを入れた状態で変換を実行した場合、変換後の画像がすべて同じ画像になるバグを修正するためのPRです。

# 修正の内容
設定をコピーする際に、画像の名前までコピーしていたので、設定のみコピーするメソッドを作成しました。