### PR TITLE
Ensure that logs are correctly parsed

### DIFF
--- a/VRCToolBox/VRCLog/Analyse/Model/VRCLogParser.cs
+++ b/VRCToolBox/VRCLog/Analyse/Model/VRCLogParser.cs
@@ -75,7 +75,7 @@ namespace VRCToolBox.VRCLog.Analyse.Model
         [GeneratedRegex(@"""([^""]+)""\s+(?:is (local|remote))")]
         private static partial Regex GetUserNameAndIsLocalRegex();
 
-        [GeneratedRegex(@"(\d{4}\.\d{2}\.\d{2} \d{2}:\d{2}:\d{2}) Log\s+-\s+\[Behaviour\] (Initialized PlayerAPI|OnPlayerLeft|Entering Room:)\s+(.*)")]
+        [GeneratedRegex(@"(\d{4}\.\d{2}\.\d{2} \d{2}:\d{2}:\d{2})\s+[a-z,A-Z]+\s+-\s+\[Behaviour\]\s+(Initialized PlayerAPI|OnPlayerLeft|Entering Room:)\s+(.*)")]
         private static partial Regex GetUserActivityRegex();
     }
 }

--- a/VRCToolBox/VRCLog/Analyse/Model/VRCLogParser.cs
+++ b/VRCToolBox/VRCLog/Analyse/Model/VRCLogParser.cs
@@ -10,10 +10,22 @@ namespace VRCToolBox.VRCLog.Analyse.Model
     /// <summary>VRChatのログを解析するクラス</summary>
     internal partial class VRCLogParser : ILogParser
     {
+        /// <summary>
+        /// プレイヤーJoin検出用の文字列
+        /// </summary>
         private const string PlayerJoin = "Initialized PlayerAPI";
+        /// <summary>
+        /// プレイヤーLeft検出用の文字列
+        /// </summary>
         private const string PlayerLeft = "OnPlayerLeft";
+        /// <summary>
+        /// ワールドに入ったタイミングの検出用文字列
+        /// </summary>
         private const string EnterWorld = "Entering Room:";
 
+        /// <summary>
+        /// このリストの文字列を含む行のみをRegexに通す
+        /// </summary>
         private static readonly List<string> _logEntries = new List<string>()
         {
             PlayerJoin,

--- a/VRCToolBox/VRCToolBox.csproj
+++ b/VRCToolBox/VRCToolBox.csproj
@@ -21,18 +21,22 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <Optimize>False</Optimize>
+    <DebugType>full</DebugType>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Optimize>False</Optimize>
+    <DebugType>full</DebugType>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <Optimize>True</Optimize>
+    <DebugType>full</DebugType>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Optimize>True</Optimize>
+    <DebugType>full</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Images\Folder.png" />


### PR DESCRIPTION
fix: #100 

VRChatのログ出力のテキストに一部変更があり、既存のままでは正しく解析が行えていなかったため、リファクタリングも込みで修正しました。